### PR TITLE
Remove all buffering

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -49,10 +49,6 @@ Logging
    :members:
    :show-inheritance:
 
-.. autoclass:: libvcs.base.BufferedProgressMixin
-   :members:
-   :show-inheritance:
-
 Utility stuff
 -------------
 

--- a/libvcs/base.py
+++ b/libvcs/base.py
@@ -10,131 +10,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import os
 import subprocess
-import sys
 
-from . import exc
-from ._compat import console_to_str, text_type, urlparse
+from ._compat import urlparse
 from .util import mkdir_p, run
 
 logger = logging.getLogger(__name__)
-
-
-class BufferedProgressMixin(object):
-    """Facilities for showing live command progress to stdout."""
-
-    def __init__(self):
-        self.indent = 0
-        self.in_progress = None
-        self.in_progress_hanging = False
-
-    def start_progress(self, msg=True):
-        assert not self.in_progress, (
-            "Tried to start_progress(%r) while in_progress %r"
-            % (msg, self.in_progress))
-        if self._show_progress():
-            if msg and isinstance(msg, text_type):
-                self.info(' ' * self.indent + msg)
-            sys.stdout.flush()
-            self.in_progress_hanging = True
-        else:
-            self.in_progress_hanging = False
-        self.in_progress = msg
-        self.last_message = None
-
-    def _show_progress(self):
-        """Should we display download progress."""
-        return sys.stdout.isatty()
-
-    def end_progress(self, msg='done.'):
-        assert self.in_progress, (
-            "Tried to end_progress without start_progress")
-        if self._show_progress():
-            if not self.in_progress_hanging and isinstance(msg, text_type):
-                # Some message has been printed out since start_progress
-                sys.stdout.write('...' + self.in_progress + msg + '\n')
-                sys.stdout.flush()
-            else:
-                # Erase any messages shown with show_progress (besides .'s)
-                self.show_progress('')
-                self.show_progress('')
-                sys.stdout.write(msg)
-                sys.stdout.flush()
-        self.in_progress = None
-        self.in_progress_hanging = False
-
-    def show_progress(self, message=None):
-        """If in progress scope with no log messages shown yet, append '.'."""
-        if self.in_progress_hanging:
-            if message is None:
-                # sys.stdout.write('.')
-                sys.stdout.flush()
-            else:
-                if self.last_message:
-                    padding = ' ' * max(
-                        0, len(self.last_message) - len(message)
-                    )
-                else:
-                    padding = ''
-                sys.stdout.write(
-                    '\r%s%s%s' %
-                    (' ' * self.indent, message, padding)
-                )
-                sys.stdout.flush()
-                self.last_message = message
-
-    def run_buffered(
-        self, cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-        env=None, cwd=None, print_stdout_on_progress_end=False,
-        *args, **kwargs
-    ):
-        """Run command with stderr directly to buffer, for CLI usage.
-
-        This method will also prefix the VCS command bin_name.
-
-        This is meant for buffering the raw progress of git/hg/etc. to CLI
-        when it is processing.
-
-        :param cwd: dir command is run from, defaults :attr:`~.path`.
-        :type cwd: string
-        :param print_stdout_on_progress_end: print final (non-buffered) stdout
-            message to buffer in cases like git pull, this would be
-            'Already up to date.' All stdout output is captured and added to
-            .stdout_data in the object returned from this method.
-        :type print_stdout_on_progress_end: bool
-        :returns: subprocess instance ``.stdout_data`` attached.
-        :rtype: :class:`Subprocess.Popen`
-        """
-        if cwd is None:
-            cwd = getattr(self, 'path', None)
-
-        cmd = [self.bin_name] + cmd
-
-        process = subprocess.Popen(
-            cmd,
-            stdout=stdout,
-            stderr=stderr,
-            env=env, cwd=cwd
-        )
-
-        self.start_progress(' '.join(cmd))
-        while True:
-            err = console_to_str(process.stderr.read(128))
-            if err == '' and process.poll() is not None:
-                break
-            elif 'ERROR' in err:
-                raise exc.LibVCSException(
-                    err + console_to_str(process.stderr.read())
-                )
-            else:
-                self.show_progress("%s" % err)
-
-        process.stdout_data = console_to_str(process.stdout.read())
-        self.end_progress(
-            '%s' % process.stdout_data if print_stdout_on_progress_end else '')
-
-        process.stderr.close()
-        process.stdout.close()
-        return process
 
 
 class RepoLoggingAdapter(logging.LoggerAdapter):
@@ -171,7 +51,8 @@ class RepoLoggingAdapter(logging.LoggerAdapter):
 
         return msg, kwargs
 
-class BaseRepo(RepoLoggingAdapter, BufferedProgressMixin, object):
+
+class BaseRepo(RepoLoggingAdapter, object):
 
     """Base class for repositories.
 
@@ -194,7 +75,6 @@ class BaseRepo(RepoLoggingAdapter, BufferedProgressMixin, object):
             urlparse.uses_fragment.extend(self.schemes)
 
         RepoLoggingAdapter.__init__(self, logger, {})
-        BufferedProgressMixin.__init__(self)
 
     @classmethod
     def from_pip_url(cls, pip_url, *args, **kwargs):
@@ -205,7 +85,7 @@ class BaseRepo(RepoLoggingAdapter, BufferedProgressMixin, object):
 
     def run(
         self, cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        env=None, cwd=None, check_returncode=True, *args, **kwargs
+        extra_env=None, cwd=None, check_returncode=True, *args, **kwargs
     ):
         """Return combined stderr/stdout from a command.
 
@@ -215,8 +95,8 @@ class BaseRepo(RepoLoggingAdapter, BufferedProgressMixin, object):
         :param cwd: dir command is run from, defaults :attr:`~.path`.
         :type cwd: string
 
-        :param check_returncode: Indicate whether a :exc:`~exc.SubprocessError` should
-        be raised if return code is different from 0.
+        :param check_returncode: Indicate whether a :exc:`~exc.SubprocessError`
+            should be raised if return code is different from 0.
         :type check_returncode: :class:`bool`
 
         :returns: combined stdout/stderr in a big string, newlines retained
@@ -225,6 +105,10 @@ class BaseRepo(RepoLoggingAdapter, BufferedProgressMixin, object):
 
         if cwd is None:
             cwd = getattr(self, 'path', None)
+
+        env = os.environ.copy()
+        if extra_env:
+            env.update(extra_env)
 
         cmd = [self.bin_name] + cmd
 

--- a/libvcs/hg.py
+++ b/libvcs/hg.py
@@ -31,8 +31,8 @@ class MercurialRepo(BaseRepo):
     def obtain(self):
         self.check_destination()
 
-        self.run_buffered(['clone', '--noupdate', '-q', self.url, self.path])
-        self.run_buffered(['update', '-q'])
+        self.run(['clone', '--noupdate', '-q', self.url, self.path])
+        self.run(['update', '-q'])
 
     def get_revision(self):
         return self.run(['parents', '--template={rev}'])
@@ -40,8 +40,8 @@ class MercurialRepo(BaseRepo):
     def update_repo(self):
         self.check_destination()
         if os.path.isdir(os.path.join(self.path, '.hg')):
-            self.run_buffered(['update'])
-            self.run_buffered(['pull', '-u'])
+            self.run(['update'])
+            self.run(['pull', '-u'])
 
         else:
             self.obtain()

--- a/libvcs/util.py
+++ b/libvcs/util.py
@@ -40,7 +40,7 @@ def run(
     shell=False,
     env=None,
     timeout=None,
-    check_returncode = True
+    check_returncode=True,
 ):
     """Run command and return output.
 
@@ -53,7 +53,7 @@ def run(
         cmd[0] = which(cmd[0])
 
     try:
-        process = subprocess.Popen(
+        proc = subprocess.Popen(
             cmd,
             stdout=stdout,
             stderr=stderr,
@@ -62,20 +62,23 @@ def run(
     except (OSError, IOError) as e:
         raise exc.LibVCSException('Unable to run command: %s' % e)
 
-    process.wait()
     all_output = []
     while True:
-        line = console_to_str(process.stdout.readline())
+        line = console_to_str(proc.stdout.readline())
         if not line:
             break
         line = line.rstrip()
         all_output.append(line + '\n')
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            logger.debug(line)  # Show the line immediately
+    proc.wait()
+
     all_output = ''.join(all_output)
 
-    if check_returncode and process.returncode:
+    if check_returncode and proc.returncode:
         logging.error(all_output)
         raise exc.SubprocessError(
-            returncode=process.returncode,
+            returncode=proc.returncode,
             cmd=cmd,
             output=all_output,
         )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -29,8 +29,7 @@ def test_repo_git_obtain_initial_commit_repo(tmpdir):
 
     git_repo = create_repo_from_pip_url(**{
         'pip_url': 'git+file://' + str(bare_repo_dir),
-        'repo_dir': str(tmpdir),
-        'name': 'obtaining a bare repo'
+        'repo_dir': str(tmpdir.join('obtaining a bare repo')),
     })
 
     git_repo.obtain(quiet=True)

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -36,12 +36,12 @@ def hg_dummy_repo_dir(tmpdir_repoparent, scope='session'):
     return repo_path
 
 
-def test_repo_mercurial(tmpdir, hg_dummy_repo_dir):
+def test_repo_mercurial(tmpdir, tmpdir_repoparent, hg_dummy_repo_dir):
     repo_name = 'my_mercurial_project'
 
     mercurial_repo = create_repo_from_pip_url(**{
         'pip_url': 'hg+file://' + hg_dummy_repo_dir,
-        'repo_dir': str(tmpdir.join(repo_name)),
+        'repo_dir': str(tmpdir_repoparent.join(repo_name)),
     })
 
     run(['hg', 'init', mercurial_repo.name],
@@ -52,7 +52,7 @@ def test_repo_mercurial(tmpdir, hg_dummy_repo_dir):
 
     test_repo_revision = run(
         ['hg', 'parents', '--template={rev}'],
-        cwd=str(tmpdir.join(repo_name)),
+        cwd=str(tmpdir_repoparent.join(repo_name)),
     )
 
     assert mercurial_repo.get_revision() == test_repo_revision


### PR DESCRIPTION
This removes buffered output from repos completely.

This gets rid of a lot of distractions and opens the way for thread
safety / easier development / leaner codebase for other developers.

See also: #6