### PR TITLE
ylibvcs.git: Fix unbound local variable 'tag_sha' error

### DIFF
--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -200,6 +200,7 @@ class GitRepo(BaseRepo):
             tag_sha = self.run(['rev-list', '--max-count=1', git_tag])
         except exc.SubprocessError as e:
             error_code = e.subprocess.returncode
+            tag_sha = ""
         self.debug("tag_sha: %s" % tag_sha)
 
         # Is the hash checkout out what we want?


### PR DESCRIPTION
This commit fixes error like this one:

```
Traceback (most recent call last):
  File "./extensions-index-checkout.py", line 150, in <module>
    duration, result = timecall(repo.update_repo)()
  File "./extensions-index-checkout.py", line 53, in wrapper
    result = method(*args, **kwargs)
  File "/home/jcfr/Projects/sandbox/libvcs/libvcs/git.py", line 198, in update_repo
    self.debug("tag_sha: %s" % tag_sha)

UnboundLocalError: local variable 'tag_sha' referenced before assignment
```